### PR TITLE
exploreページを作成

### DIFF
--- a/app/explore/page.test.tsx
+++ b/app/explore/page.test.tsx
@@ -1,21 +1,58 @@
-import { render, screen } from '@testing-library/react';
 import Explore from './page';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-describe('explore/page component', () => {
-  beforeEach(() => {
+describe('Explore component', () => {
+  test('renders Explore component', () => {
     render(<Explore />);
-  })
-
-  test('renders explore/page component', () => {
-    const heroText = screen.getByText('Discover the Ages: Explore Masterpieces by Artist');
-    expect(heroText).toBeInTheDocument();
+    const heading = screen.getByText('Discover the Ages: Explore Masterpieces by Artist');
+    expect(heading).toBeInTheDocument();
   });
 
-  test('renders all artist cards', () => {
-    const artistNames = ['Vincent van Gogh', 'Rembrandt van Rijn', 'Johannes Vermeer'];
+  test('renders initial artist list', () => {
+    render(<Explore />);
+    const artistNames = [
+      'Vincent van Gogh',
+      'Rembrandt van Rijn',
+      'Johannes Vermeer'
+    ];
     artistNames.forEach(name => {
-      const cardTitle = screen.getByText(name);
-      expect(cardTitle).toBeInTheDocument();
+      expect(screen.getByText(name)).toBeInTheDocument();
     });
-  })
-})
+  });
+
+  test('updates selected artist on button click', async () => {
+    render(<Explore />);
+    const selectButtons = screen.getAllByText('Select');
+    await userEvent.click(selectButtons[0]);
+
+    await waitFor(() => {
+      const selectedCards = screen.getAllByText('Vincent van Gogh');
+      selectedCards.forEach(card => {
+        const selectedCard = card.closest('.card');
+        expect(selectedCard).toHaveClass('bg-blue-100');
+      });
+    });
+  });
+
+  test('updates selected artist correctly when another button is clicked', async () => {
+    render(<Explore />);
+    const selectButtons = screen.getAllByText('Select');
+    await userEvent.click(selectButtons[0]);
+    await userEvent.click(selectButtons[1]);
+    await waitFor(() => {
+      const rembrandtCards = screen.getAllByText('Rembrandt van Rijn');
+      rembrandtCards.forEach(card => {
+        const selectedCard = card.closest('.card');
+        expect(selectedCard).toHaveClass('bg-blue-100');
+      });
+
+      const vanGoghCards = screen.getAllByText('Vincent van Gogh');
+      vanGoghCards.forEach(card => {
+        const deselectedCard = card.closest('.card');
+        expect(deselectedCard).not.toHaveClass('bg-blue-100');
+      });
+    });
+  });
+});

--- a/app/explore/page.test.tsx
+++ b/app/explore/page.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import Explore from './page';
+
+describe('explore/page component', () => {
+  beforeEach(() => {
+    render(<Explore />);
+  })
+
+  test('renders explore/page component', () => {
+    const heroText = screen.getByText('Discover the Ages: Explore Masterpieces by Artist');
+    expect(heroText).toBeInTheDocument();
+  });
+
+  test('renders all artist cards', () => {
+    const artistNames = ['Vincent van Gogh', 'Rembrandt van Rijn', 'Johannes Vermeer'];
+    artistNames.forEach(name => {
+      const cardTitle = screen.getByText(name);
+      expect(cardTitle).toBeInTheDocument();
+    });
+  })
+})

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,37 +1,56 @@
+'use client'
 import Image from 'next/image'
+import { useState } from 'react'
+import clsx from 'clsx'
 
 export default function Explore() {
+  const [artistId, setArtistId] = useState<number>(0)
+
   type Artist = {
     id: number,
     artistDisplayName: string,
     artistBeginDate: number,
     deathYear: number,
-    imageURL: string
+    imageURL: string,
+    selected: boolean
   }
 
-  const artistList: Artist[] = [
+  const initialArtistList: Artist[] = [
     {
       id: 1,
       artistDisplayName: 'Vincent van Gogh',
       artistBeginDate: 1853,
       deathYear: 1890,
-      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP130999.jpg'
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP130999.jpg',
+      selected: false
     },
     {
       id: 2,
       artistDisplayName: 'Rembrandt van Rijn',
       artistBeginDate: 1881,
       deathYear: 1973,
-      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145909.jpg'
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145909.jpg',
+      selected: false
     },
     {
       id: 3,
       artistDisplayName: 'Johannes Vermeer',
       artistBeginDate: 1452,
       deathYear: 1519,
-      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145924.jpg'
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145924.jpg',
+      selected: false
     }
   ]
+
+  const [artistList, setArtistList] = useState<Artist[]>(initialArtistList)
+
+  const handleArtistClick = (id: number) => {
+    const updatedArtistList = artistList.map((artist: Artist) => {
+      return { ...artist, selected: artist.id === id }
+    })
+    setArtistId(id)
+    setArtistList(updatedArtistList)
+  }
 
   return (
     <div className='max-w-screen-lg mx-auto p-5'>
@@ -39,8 +58,16 @@ export default function Explore() {
       <p className='m-6 text-pretty'>Select an Artist: Explore the masterpieces crafted by renowned artists and dive deep into their unique styles and contributions to the world of art.</p>
       <div className='flex justify-between w-full'>
         {artistList.map((artist, index) => (
-          <div className="card w-96 bg-base-100 shadow-xl m-6" key={index}>
-            <Image
+          <div
+            key={index}
+            className={clsx(
+              "card w-96 bg-base-100 shadow-xl m-6",
+            {
+              'bg-blue-100': artist.selected
+            }
+            )}
+          >
+          <Image
               src={artist.imageURL}
               alt={artist.artistDisplayName}
               width={400}
@@ -50,7 +77,7 @@ export default function Explore() {
               <h2 className="card-title">{artist.artistDisplayName}</h2>
               <p>{artist.artistBeginDate} - {artist.deathYear}</p>
               <div className="card-actions justify-end">
-                <button className="btn btn-primary">Get Start</button>
+                <button className="btn btn-primary" onClick={() => handleArtistClick(artist.id)}>Select</button>
               </div>
             </div>
           </div>

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,29 +1,37 @@
 import Image from 'next/image'
 
 export default function Explore() {
-const artistList = [
-  {
-    id: 1,
-    artistDisplayName: 'Vincent van Gogh',
-    artistBeginDate: 1853,
-    deathYear: 1890,
-    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP130999.jpg'
-  },
-  {
-    id: 2,
-    artistDisplayName: 'Rembrandt van Rijn',
-    artistBeginDate: 1881,
-    deathYear: 1973,
-    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145909.jpg'
-  },
-  {
-    id: 3,
-    artistDisplayName: 'Johannes Vermeer',
-    artistBeginDate: 1452,
-    deathYear: 1519,
-    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145924.jpg'
+  type Artist = {
+    id: number,
+    artistDisplayName: string,
+    artistBeginDate: number,
+    deathYear: number,
+    imageURL: string
   }
-]
+
+  const artistList: Artist[] = [
+    {
+      id: 1,
+      artistDisplayName: 'Vincent van Gogh',
+      artistBeginDate: 1853,
+      deathYear: 1890,
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP130999.jpg'
+    },
+    {
+      id: 2,
+      artistDisplayName: 'Rembrandt van Rijn',
+      artistBeginDate: 1881,
+      deathYear: 1973,
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145909.jpg'
+    },
+    {
+      id: 3,
+      artistDisplayName: 'Johannes Vermeer',
+      artistBeginDate: 1452,
+      deathYear: 1519,
+      imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145924.jpg'
+    }
+  ]
 
   return (
     <div className='max-w-screen-lg mx-auto p-5'>
@@ -34,7 +42,7 @@ const artistList = [
           <div className="card w-96 bg-base-100 shadow-xl m-6" key={index}>
             <Image
               src={artist.imageURL}
-              alt="sample"
+              alt={artist.artistDisplayName}
               width={400}
               height={400}
             />

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image'
+
+export default function Explore() {
+const artistList = [
+  {
+    id: 1,
+    artistDisplayName: 'Vincent van Gogh',
+    artistBeginDate: 1853,
+    deathYear: 1890,
+    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP130999.jpg'
+  },
+  {
+    id: 2,
+    artistDisplayName: 'Rembrandt van Rijn',
+    artistBeginDate: 1881,
+    deathYear: 1973,
+    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145909.jpg'
+  },
+  {
+    id: 3,
+    artistDisplayName: 'Johannes Vermeer',
+    artistBeginDate: 1452,
+    deathYear: 1519,
+    imageURL: 'https://images.metmuseum.org/CRDImages/ep/web-large/DP145924.jpg'
+  }
+]
+
+  return (
+    <div className='max-w-screen-lg mx-auto p-5'>
+      <h2 className='text-2xl text-center font-semibold mb-6'>Discover the Ages: Explore Masterpieces by Artist</h2>
+      <p className='m-6 text-pretty'>Select an Artist: Explore the masterpieces crafted by renowned artists and dive deep into their unique styles and contributions to the world of art.</p>
+      <div className='flex justify-between w-full'>
+        {artistList.map((artist, index) => (
+          <div className="card w-96 bg-base-100 shadow-xl m-6" key={index}>
+            <Image
+              src={artist.imageURL}
+              alt="sample"
+              width={400}
+              height={400}
+            />
+            <div className="card-body">
+              <h2 className="card-title">{artist.artistDisplayName}</h2>
+              <p>{artist.artistBeginDate} - {artist.deathYear}</p>
+              <div className="card-actions justify-end">
+                <button className="btn btn-primary">Get Start</button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/hero.test.tsx
+++ b/app/hero.test.tsx
@@ -4,6 +4,8 @@ import mockRouter from 'next-router-mock';
 import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 
+jest.mock('next/router', () => require('next-router-mock'));
+
 jest.mock('next/link', () => {
   interface MockLinkProps {
     children: ReactNode;
@@ -11,36 +13,22 @@ jest.mock('next/link', () => {
   }
 
   const MockLink = ({ children, href }: MockLinkProps) => {
+    console.log({children, href})
     return <a href={href} onClick={() => mockRouter.push(href)}>{children}</a>;
-  };
-  MockLink.displayName = 'MockLink';
+  }
+  MockLink.displayName = 'Link';
   return MockLink;
 });
 
 describe('Hero component', () => {
-  const originalError = console.error;
-  beforeAll(() => {
-    console.error = (...args) => {
-      if (/Not implemented: navigation/.test(args[0])) {
-        return;
-      }
-      originalError.call(console, ...args);
-    };
-  });
-
-  afterAll(() => {
-    console.error = originalError;
-  });
-
   beforeEach(() => {
-    mockRouter.setCurrentUrl('/');
     render(<Hero />);
   });
 
-  test('renders Hero component', () => {
+  test ('renders Hero component', () => {
     const heroText = screen.getByText('Art Timeline');
     expect(heroText).toBeInTheDocument();
-  });
+  })
 
   test('renders description', () => {
     const descriptionText = screen.getByText(/Explore the Art of Time: Journey through centuries of creativity, from ancient masterpieces to modern expressions. Discover how art has shaped history and continues to inspire the world today. Dive into the 'Art Timeline' and let each stroke tell its story./i);
@@ -48,18 +36,14 @@ describe('Hero component', () => {
   });
 
   test('renders get started button', () => {
-    const getStartedButton = screen.getByRole('link', { name: /get started/i });
+    const getStartedButton = screen.getByRole('button', { name: /get started/i });
     expect(getStartedButton).toBeInTheDocument();
   });
 
   test('navigates to /explore when get started button is clicked', async () => {
-    const getStartedButton = screen.getByRole('link', { name: /get started/i });
-
-    await userEvent.click(getStartedButton);
-
-    await waitFor(() => {
-      expect(mockRouter).toMatchObject({ pathname: '/explore' });
-    });
+    mockRouter.setCurrentUrl('/');
+    const getStartedButton = screen.getByRole('button', { name: /get started/i });
+    userEvent.click(getStartedButton);
+    await waitFor(() => expect(mockRouter.asPath).toEqual('/explore'));
   });
-});
-
+})

--- a/app/hero.test.tsx
+++ b/app/hero.test.tsx
@@ -1,15 +1,46 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Hero from './hero';
+import mockRouter from 'next-router-mock';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+
+jest.mock('next/link', () => {
+  interface MockLinkProps {
+    children: ReactNode;
+    href: string;
+  }
+
+  const MockLink = ({ children, href }: MockLinkProps) => {
+    return <a href={href} onClick={() => mockRouter.push(href)}>{children}</a>;
+  };
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
 
 describe('Hero component', () => {
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = (...args) => {
+      if (/Not implemented: navigation/.test(args[0])) {
+        return;
+      }
+      originalError.call(console, ...args);
+    };
+  });
+
+  afterAll(() => {
+    console.error = originalError;
+  });
+
   beforeEach(() => {
+    mockRouter.setCurrentUrl('/');
     render(<Hero />);
   });
 
-  test ('renders Hero component', () => {
+  test('renders Hero component', () => {
     const heroText = screen.getByText('Art Timeline');
     expect(heroText).toBeInTheDocument();
-  })
+  });
 
   test('renders description', () => {
     const descriptionText = screen.getByText(/Explore the Art of Time: Journey through centuries of creativity, from ancient masterpieces to modern expressions. Discover how art has shaped history and continues to inspire the world today. Dive into the 'Art Timeline' and let each stroke tell its story./i);
@@ -17,7 +48,18 @@ describe('Hero component', () => {
   });
 
   test('renders get started button', () => {
-    const getStartedButton = screen.getByRole('button', { name: /get started/i });
+    const getStartedButton = screen.getByRole('link', { name: /get started/i });
     expect(getStartedButton).toBeInTheDocument();
   });
-})
+
+  test('navigates to /explore when get started button is clicked', async () => {
+    const getStartedButton = screen.getByRole('link', { name: /get started/i });
+
+    await userEvent.click(getStartedButton);
+
+    await waitFor(() => {
+      expect(mockRouter).toMatchObject({ pathname: '/explore' });
+    });
+  });
+});
+

--- a/app/hero.test.tsx
+++ b/app/hero.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import Hero from './hero';
+import { Router } from 'next/router';
 import mockRouter from 'next-router-mock';
 import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
@@ -13,9 +14,8 @@ jest.mock('next/link', () => {
   }
 
   const MockLink = ({ children, href }: MockLinkProps) => {
-    console.log({children, href})
     return <a href={href} onClick={() => mockRouter.push(href)}>{children}</a>;
-  }
+  };
   MockLink.displayName = 'Link';
   return MockLink;
 });
@@ -44,6 +44,7 @@ describe('Hero component', () => {
     mockRouter.setCurrentUrl('/');
     const getStartedButton = screen.getByRole('button', { name: /get started/i });
     userEvent.click(getStartedButton);
+
     await waitFor(() => expect(mockRouter.asPath).toEqual('/explore'));
   });
 })

--- a/app/hero.tsx
+++ b/app/hero.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 export default function Navbar() {
   return (
@@ -14,7 +15,11 @@ export default function Navbar() {
         <div className="max-w-md">
           <h1 className="mb-5 text-5xl font-bold">Art Timeline</h1>
           <p className="mb-5">Explore the Art of Time: Journey through centuries of creativity, from ancient masterpieces to modern expressions. Discover how art has shaped history and continues to inspire the world today. Dive into the 'Art Timeline' and let each stroke tell its story.</p>
-          <button className="btn btn-primary">Get Started</button>
+          <Link href='/explore'>
+            <button className="btn btn-primary" aria-current="page">
+                Get Started
+            </button>
+          </Link>
         </div>
       </div>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Navbar from "./navbar";
+import Footer from "./footer";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -16,7 +18,11 @@ export default function RootLayout({
   }>) {
     return (
       <html lang="en">
-        <body className={inter.className}>{children}</body>
+        <body className={inter.className}>
+          <Navbar />
+          {children}
+          <Footer />
+        </body>
       </html>
     );
 }

--- a/app/navbar.test.tsx
+++ b/app/navbar.test.tsx
@@ -1,7 +1,39 @@
-import { render, screen } from '@testing-library/react';
-import Navar from './navbar';
+import { render, screen, waitFor } from '@testing-library/react';
+import Navbar from './navbar';
+import mockRouter from 'next-router-mock';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
 
-test('renders navbar component', () => {
-  render(<Navar />);
-  expect(screen.getByText('Art Timeline')).toBeInTheDocument();
+jest.mock('next/router', () => require('next-router-mock'));
+
+jest.mock('next/link', () => {
+  interface MockLinkProps {
+    children: ReactNode;
+    href: string;
+  }
+
+  const MockLink = ({ children, href }: MockLinkProps) => {
+    return <a href={href} onClick={() => mockRouter.push(href)}>{children}</a>;
+  }
+  MockLink.displayName = 'Link';
+  return MockLink;
+})
+
+describe('Navbar component', () => {
+  beforeEach(() =>{
+    mockRouter.setCurrentUrl('/explore');
+    render(<Navbar />)
+  })
+
+  test('renders navbar component', () => {
+    expect(screen.getByText('Art Timeline')).toBeInTheDocument();
+  })
+
+  test('navigates to / when get started button is clicked', async () => {
+    mockRouter.setCurrentUrl('/explore');
+    const getStartedButton = screen.getByRole('link', { name: /Art Timeline/i});
+    userEvent.click(getStartedButton);
+
+    await waitFor(() => expect(mockRouter.asPath).toEqual('/'))
+  })
 })

--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -1,9 +1,15 @@
+import Link from "next/link";
+
 export default function Navbar() {
   return (
-    <>
-      <div className="navbar bg-base-100">
-        <a className="btn btn-ghost text-xl">Art Timeline</a>
+    <div className="navbar bg-base-100">
+      <div className="container mx-auto">
+        <div className="flex items-center justify-between">
+          <Link href="/">
+            <p className="text-xl font-bold">Art Timeline</p>
+          </Link>
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,9 @@
-import Navbar from './navbar'
-import Footer from './footer'
 import Hero from './hero'
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col p-6">
-      <Navbar />
       <Hero />
-      <Footer />
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@testing-library/user-event": "^14.5.2",
+    "clsx": "^2.1.1",
     "next": "^14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@testing-library/user-event": "^14.5.2",
     "next": "^14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -27,6 +28,7 @@
     "eslint-config-next": "14.2.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "next-router-mock": "^0.9.13",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,6 +790,11 @@
     "@testing-library/dom" "^10.0.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.5.2":
+  version "14.5.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
+  integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -3646,6 +3651,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+next-router-mock@^0.9.13:
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.13.tgz#bdee2011ea6c09e490121c354ef917f339767f72"
+  integrity sha512-906n2RRaE6Y28PfYJbaz5XZeJ6Tw8Xz1S6E31GGwZ0sXB6/XjldD1/2azn1ZmBmRk5PQRkzjg+n+RHZe5xQzWA==
 
 next@^14.2.3:
   version "14.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1500,6 +1500,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
## issue
#8 

## やったこと
- [x]  exploreページの作成
- [x] トップページのボタンからexploreに遷移できる
- [x]   カード形式で作家を選択できるようにする
- [x] 選択した作家を視覚的にわかりやすくする
- [x]  exlpreからトップページに戻ることができる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an `Explore` page displaying a list of artists with their details and images.
  - Enhanced `Navbar` and `Footer` components for consistent layout across pages.

- **Bug Fixes**
  - Corrected the component name from `Navar` to `Navbar` in tests.

- **Improvements**
  - Updated `Navbar` to include a container, flex layout, and a link for "Art Timeline."
  - Wrapped the button in `Hero` component with a `Link` for navigation to '/explore'.

- **Tests**
  - Added comprehensive test cases for `Explore` component.
  - Enhanced `Navbar` and `Hero` component tests with navigation testing.

- **Dependencies**
  - Added `@testing-library/user-event`, `clsx`, and `next-router-mock` to dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->